### PR TITLE
fix the playerinput.devices[0] references issue

### DIFF
--- a/InputSystem_Warriors_Project/Assets/Scripts/Behaviours/Player/PlayerController.cs
+++ b/InputSystem_Warriors_Project/Assets/Scripts/Behaviours/Player/PlayerController.cs
@@ -29,6 +29,8 @@ public class PlayerController : MonoBehaviour
     //Current Control Scheme
     private string currentControlScheme;
 
+    private bool playerSetupDone = false;
+
 
     //This is called from the GameManager; when the game is being setup.
     public void SetupPlayer(int newPlayerID)
@@ -40,6 +42,8 @@ public class PlayerController : MonoBehaviour
         playerMovementBehaviour.SetupBehaviour();
         playerAnimationBehaviour.SetupBehaviour();
         playerVisualsBehaviour.SetupBehaviour(playerID, playerInput);
+
+        playerSetupDone = true;
     }
 
 
@@ -83,6 +87,7 @@ public class PlayerController : MonoBehaviour
     //(IE: Keyboard -> Xbox Controller)
     public void OnControlsChanged()
     {
+        if (!playerSetupDone) return;
 
         if(playerInput.currentControlScheme != currentControlScheme)
         {

--- a/InputSystem_Warriors_Project/Assets/Scripts/Utilities/DeviceDisplayConfigurator.cs
+++ b/InputSystem_Warriors_Project/Assets/Scripts/Utilities/DeviceDisplayConfigurator.cs
@@ -84,7 +84,7 @@ public class DeviceDisplayConfigurator : ScriptableObject
         {
             if(listDeviceSets[i].deviceRawPath == currentDeviceRawPath)
             {
-                if(listDeviceSets[i].deviceDisplaySettings.deviceHasContextIcons != null)
+                if(listDeviceSets[i].deviceDisplaySettings.deviceHasContextIcons)
                 {
                     displaySpriteIcon = FilterForDeviceInputBinding(listDeviceSets[i], playerInputDeviceInputBinding);
                 }


### PR DESCRIPTION
Fix the issue:
https://github.com/UnityTechnologies/InputSystem_Warriors/issues/12:
playerInput.devices[0] is accessed before the player setup is done. The error is triggered by PlayerController.OnControlsChanged before the SetupPlayer() is called.

NullReferenceException: Object reference not set to an instance of an object
DeviceDisplayConfigurator.GetDeviceName (UnityEngine.InputSystem.PlayerInput playerInput) (at Assets/Scripts/Utilities/DeviceDisplayConfigurator.cs:33)
PlayerVisualsBehaviour.UpdateUIDisplay () (at Assets/Scripts/Behaviours/Player/PlayerVisualsBehaviour.cs:49)
PlayerVisualsBehaviour.UpdatePlayerVisuals () (at Assets/Scripts/Behaviours/Player/PlayerVisualsBehaviour.cs:41)
PlayerController.OnControlsChanged () (at Assets/Scripts/Behaviours/Player/PlayerController.cs:91)
UnityEngine.Events.InvokableCall.Invoke () (at <82c503977c5347cf82f44677f633fcf6>:0)
UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) (at <82c503977c5347cf82f44677f633fcf6>:0)
UnityEngine.InputSystem.PlayerInput.HandleControlsChanged () (at Library/PackageCache/com.unity.inputsystem@1.2.0/InputSystem/Plugins/PlayerInput/PlayerInput.cs:1806)
UnityEngine.InputSystem.PlayerInput.OnEnable () (at Library/PackageCache/com.unity.inputsystem@1.2.0/InputSystem/Plugins/PlayerInput/PlayerInput.cs:1660)

Fix the build warning:
Assets\Scripts\Utilities\DeviceDisplayConfigurator.cs(87,20): warning CS0472: The result of the expression is always 'true' since a value of type 'bool' is never equal to 'null' of type 'bool?'